### PR TITLE
Add browser keyboard and mouse activity tracking

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -413,12 +413,15 @@
 
             try {
                 const action = trackingPaused ? 'resume' : 'pause';
-                await fetch(`${getApiUrl()}/api/sessions/${sessionId}/${action}`, {
+                const response = await fetch(`${getApiUrl()}/api/sessions/${sessionId}/${action}`, {
                     method: 'POST',
                     headers: {
                         'X-User-ID': userId,
                     },
                 });
+                if (!response.ok) {
+                    throw new Error(`Failed to ${action} session (${response.status} ${response.statusText})`);
+                }
 
                 trackingPaused = !trackingPaused;
                 document.getElementById('status').className = trackingPaused ? 'status inactive' : 'status active';
@@ -459,21 +462,25 @@
         }
 
         function recordKeyboardActivity() {
+            if (!sessionId || trackingPaused) return;
             activityBuffer.keypressCount += 1;
             markActivity();
         }
 
         function recordMouseMoveActivity() {
+            if (!sessionId || trackingPaused) return;
             activityBuffer.mouseMoveCount += 1;
             markActivity();
         }
 
         function recordMouseClickActivity() {
+            if (!sessionId || trackingPaused) return;
             activityBuffer.mouseClickCount += 1;
             markActivity();
         }
 
         function recordScrollActivity() {
+            if (!sessionId || trackingPaused) return;
             activityBuffer.scrollCount += 1;
             markActivity();
         }
@@ -527,7 +534,7 @@
         async function postActivity(type, data) {
             const userId = getUserId();
             if (!sessionId || !userId) return;
-            await fetch(`${getApiUrl()}/api/activity`, {
+            const response = await fetch(`${getApiUrl()}/api/activity`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -535,6 +542,9 @@
                 },
                 body: JSON.stringify({ sessionId, type, data: { type, ...data } }),
             });
+            if (!response.ok) {
+                throw new Error(`Activity sync failed (${response.status} ${response.statusText})`);
+            }
         }
 
         async function flushActivity() {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -282,6 +282,17 @@
         let sessionId = null;
         let startTime = null;
         let durationInterval = null;
+        let activityFlushInterval = null;
+        let activityTickInterval = null;
+        let trackingPaused = false;
+        let lastActivityAt = 0;
+        const activityBuffer = {
+            keypressCount: 0,
+            mouseMoveCount: 0,
+            mouseClickCount: 0,
+            scrollCount: 0,
+            activeTime: 0,
+        };
 
         function log(message, type = 'info') {
             const logDiv = document.getElementById('log');
@@ -331,6 +342,7 @@
                 const data = await response.json();
                 sessionId = data.session.id;
                 startTime = Date.now();
+                trackingPaused = false;
 
                 document.getElementById('status').className = 'status active';
                 document.getElementById('status').textContent = 'Tracking Active';
@@ -338,16 +350,14 @@
                 
                 document.querySelector('.btn-primary').disabled = true;
                 document.querySelector('.btn-secondary').disabled = false;
+                document.querySelector('.btn-secondary').textContent = '⏸️ Pause';
                 document.querySelector('.btn-danger').disabled = false;
 
                 log('Session started: ' + sessionId, 'success');
                 
                 // Start duration counter
                 durationInterval = setInterval(updateDuration, 1000);
-
-                // Simulate some activity
-                setTimeout(() => trackGithubEvent(), 3000);
-                setTimeout(() => trackAgentPrompt(), 6000);
+                startActivityTracking();
 
             } catch (error) {
                 log('Failed to start session: ' + error.message, 'error');
@@ -378,6 +388,8 @@
                 document.querySelector('.btn-danger').disabled = true;
 
                 clearInterval(durationInterval);
+                await flushActivity();
+                stopActivityTracking();
                 
                 log('Session ended. Duration: ' + Math.floor(data.session.duration / 1000 / 60) + ' minutes', 'success');
                 
@@ -386,6 +398,7 @@
                 
                 sessionId = null;
                 startTime = null;
+                trackingPaused = false;
 
             } catch (error) {
                 log('Failed to end session: ' + error.message, 'error');
@@ -399,22 +412,32 @@
             if (!userId) return;
 
             try {
-                await fetch(`${getApiUrl()}/api/sessions/${sessionId}/pause`, {
+                const action = trackingPaused ? 'resume' : 'pause';
+                await fetch(`${getApiUrl()}/api/sessions/${sessionId}/${action}`, {
                     method: 'POST',
                     headers: {
                         'X-User-ID': userId,
                     },
                 });
 
-                document.getElementById('status').className = 'status inactive';
-                document.getElementById('status').textContent = 'Paused';
-                
-                clearInterval(durationInterval);
-                
-                log('Session paused', 'success');
+                trackingPaused = !trackingPaused;
+                document.getElementById('status').className = trackingPaused ? 'status inactive' : 'status active';
+                document.getElementById('status').textContent = trackingPaused ? 'Paused' : 'Tracking Active';
+                document.querySelector('.btn-secondary').textContent = trackingPaused ? '▶️ Resume' : '⏸️ Pause';
+
+                if (trackingPaused) {
+                    clearInterval(durationInterval);
+                    await flushActivity();
+                    log('Session paused', 'success');
+                } else {
+                    startTime = Date.now() - getDisplayedDurationMs();
+                    durationInterval = setInterval(updateDuration, 1000);
+                    markActivity();
+                    log('Session resumed', 'success');
+                }
 
             } catch (error) {
-                log('Failed to pause session: ' + error.message, 'error');
+                log('Failed to update session: ' + error.message, 'error');
             }
         }
 
@@ -422,6 +445,138 @@
             if (!startTime) return;
             const duration = Math.floor((Date.now() - startTime) / 1000 / 60);
             document.getElementById('duration').textContent = duration + 'm';
+        }
+
+        function getDisplayedDurationMs() {
+            const text = document.getElementById('duration').textContent || '0m';
+            const minutes = parseInt(text, 10);
+            return Number.isFinite(minutes) ? minutes * 60 * 1000 : 0;
+        }
+
+        function markActivity() {
+            if (!sessionId || trackingPaused) return;
+            lastActivityAt = Date.now();
+        }
+
+        function recordKeyboardActivity() {
+            activityBuffer.keypressCount += 1;
+            markActivity();
+        }
+
+        function recordMouseMoveActivity() {
+            activityBuffer.mouseMoveCount += 1;
+            markActivity();
+        }
+
+        function recordMouseClickActivity() {
+            activityBuffer.mouseClickCount += 1;
+            markActivity();
+        }
+
+        function recordScrollActivity() {
+            activityBuffer.scrollCount += 1;
+            markActivity();
+        }
+
+        function startActivityTracking() {
+            resetActivityBuffer();
+            lastActivityAt = Date.now();
+            window.addEventListener('keydown', recordKeyboardActivity);
+            window.addEventListener('mousemove', recordMouseMoveActivity, { passive: true });
+            window.addEventListener('click', recordMouseClickActivity, { passive: true });
+            window.addEventListener('scroll', recordScrollActivity, { passive: true });
+            activityTickInterval = setInterval(() => {
+                if (!trackingPaused && Date.now() - lastActivityAt < 15000) {
+                    activityBuffer.activeTime += 5;
+                }
+                updateActivityLevel();
+            }, 5000);
+            activityFlushInterval = setInterval(flushActivity, 30000);
+            log('Keyboard and mouse activity tracking enabled (counts only)', 'success');
+        }
+
+        function stopActivityTracking() {
+            window.removeEventListener('keydown', recordKeyboardActivity);
+            window.removeEventListener('mousemove', recordMouseMoveActivity);
+            window.removeEventListener('click', recordMouseClickActivity);
+            window.removeEventListener('scroll', recordScrollActivity);
+            clearInterval(activityTickInterval);
+            clearInterval(activityFlushInterval);
+            resetActivityBuffer();
+            updateActivityLevel('Stopped');
+        }
+
+        function resetActivityBuffer() {
+            activityBuffer.keypressCount = 0;
+            activityBuffer.mouseMoveCount = 0;
+            activityBuffer.mouseClickCount = 0;
+            activityBuffer.scrollCount = 0;
+            activityBuffer.activeTime = 0;
+        }
+
+        function updateActivityLevel(label = null) {
+            const level = label || (
+                activityBuffer.keypressCount + activityBuffer.mouseClickCount + activityBuffer.scrollCount > 20 ||
+                activityBuffer.mouseMoveCount > 80 ? 'High' :
+                activityBuffer.keypressCount + activityBuffer.mouseClickCount + activityBuffer.scrollCount > 0 ||
+                activityBuffer.mouseMoveCount > 0 ? 'Active' : 'Idle'
+            );
+            document.getElementById('activityLevel').textContent = level;
+        }
+
+        async function postActivity(type, data) {
+            const userId = getUserId();
+            if (!sessionId || !userId) return;
+            await fetch(`${getApiUrl()}/api/activity`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-User-ID': userId,
+                },
+                body: JSON.stringify({ sessionId, type, data: { type, ...data } }),
+            });
+        }
+
+        async function flushActivity() {
+            if (!sessionId) return;
+
+            const snapshot = { ...activityBuffer };
+            if (
+                snapshot.keypressCount === 0 &&
+                snapshot.mouseMoveCount === 0 &&
+                snapshot.mouseClickCount === 0 &&
+                snapshot.scrollCount === 0 &&
+                snapshot.activeTime === 0
+            ) {
+                return;
+            }
+            resetActivityBuffer();
+
+            try {
+                if (snapshot.keypressCount > 0) {
+                    await postActivity('keyboard', {
+                        keypressCount: snapshot.keypressCount,
+                        activeTime: snapshot.activeTime,
+                    });
+                }
+                if (snapshot.mouseMoveCount > 0 || snapshot.mouseClickCount > 0 || snapshot.scrollCount > 0) {
+                    await postActivity('mouse', {
+                        moveCount: snapshot.mouseMoveCount,
+                        clickCount: snapshot.mouseClickCount,
+                        scrollCount: snapshot.scrollCount,
+                        activeTime: snapshot.keypressCount > 0 ? 0 : snapshot.activeTime,
+                    });
+                }
+                updateActivityLevel();
+                log(`Activity synced: ${snapshot.keypressCount} keys, ${snapshot.mouseMoveCount} moves, ${snapshot.mouseClickCount} clicks`, 'success');
+            } catch (error) {
+                activityBuffer.keypressCount += snapshot.keypressCount;
+                activityBuffer.mouseMoveCount += snapshot.mouseMoveCount;
+                activityBuffer.mouseClickCount += snapshot.mouseClickCount;
+                activityBuffer.scrollCount += snapshot.scrollCount;
+                activityBuffer.activeTime += snapshot.activeTime;
+                log('Failed to sync activity: ' + error.message, 'error');
+            }
         }
 
         async function trackGithubEvent() {
@@ -507,6 +662,8 @@
                 const { summary } = await response.json();
                 
                 document.getElementById('githubEvents').textContent = summary.githubEvents;
+                document.getElementById('activityLevel').textContent =
+                    `${summary.keyboardActivity} keys / ${summary.mouseActivity} mouse`;
                 document.getElementById('productivity').textContent = summary.productivity.toUpperCase();
                 
                 log('Summary generated: ' + summary.productivity + ' productivity', 'success');

--- a/src/worker.py
+++ b/src/worker.py
@@ -64,6 +64,15 @@ def _row_to_activity(row):
     }
 
 
+def _non_negative_int(payload, key, default=0):
+    if not isinstance(payload, dict):
+        return default
+    try:
+        return max(int(payload.get(key, default)), 0)
+    except (TypeError, ValueError):
+        return default
+
+
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
@@ -317,17 +326,17 @@ async def handle_get_summary(request, env, session_id):
         if t == "github":
             summary["githubEvents"] += 1
         elif t == "keyboard":
-            data = event.get("data", {})
-            summary["keyboardActivity"] += data.get("keypressCount", 1)
-            summary["activeTime"] += data.get("activeTime", 0)
+            data = event.get("data")
+            summary["keyboardActivity"] += _non_negative_int(data, "keypressCount", 1)
+            summary["activeTime"] += _non_negative_int(data, "activeTime", 0)
         elif t == "mouse":
-            data = event.get("data", {})
+            data = event.get("data")
             summary["mouseActivity"] += (
-                data.get("moveCount", 0)
-                + data.get("clickCount", 0)
-                + data.get("scrollCount", 0)
+                _non_negative_int(data, "moveCount", 0)
+                + _non_negative_int(data, "clickCount", 0)
+                + _non_negative_int(data, "scrollCount", 0)
             ) or 1
-            summary["activeTime"] += data.get("activeTime", 0)
+            summary["activeTime"] += _non_negative_int(data, "activeTime", 0)
         elif t == "agent-prompt":
             summary["agentPrompts"] += 1
         elif t == "screenshot":

--- a/src/worker.py
+++ b/src/worker.py
@@ -317,11 +317,17 @@ async def handle_get_summary(request, env, session_id):
         if t == "github":
             summary["githubEvents"] += 1
         elif t == "keyboard":
-            summary["keyboardActivity"] += 1
-            summary["activeTime"] += event.get("data", {}).get("activeTime", 0)
+            data = event.get("data", {})
+            summary["keyboardActivity"] += data.get("keypressCount", 1)
+            summary["activeTime"] += data.get("activeTime", 0)
         elif t == "mouse":
-            summary["mouseActivity"] += 1
-            summary["activeTime"] += event.get("data", {}).get("activeTime", 0)
+            data = event.get("data", {})
+            summary["mouseActivity"] += (
+                data.get("moveCount", 0)
+                + data.get("clickCount", 0)
+                + data.get("scrollCount", 0)
+            ) or 1
+            summary["activeTime"] += data.get("activeTime", 0)
         elif t == "agent-prompt":
             summary["agentPrompts"] += 1
         elif t == "screenshot":


### PR DESCRIPTION
## Summary
- add privacy-preserving keyboard and mouse activity aggregation to the browser dashboard
- flush aggregate activity events to the existing /api/activity endpoint while a session is running
- update session summaries to count aggregated keyboard and mouse values instead of counting each batch as a single event

## Testing
- python -m py_compile src/worker.py
- git diff --check

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time activity tracking during sessions (keyboard, mouse moves/clicks, scrolls) with start/pause/resume/stop controls.
  * Session summary now shows a combined activity-level based on keyboard and mouse activity.

* **Improvements**
  * Local buffering with periodic syncing and lifecycle-aware flush on pause/stop to improve reliability and reduce data loss.
  * Backend aggregation updated to better combine mouse inputs for more accurate activity metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OWASP-BLT/BLT-Timer-Web/pull/22)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->